### PR TITLE
Handling missed out predictions during scoring

### DIFF
--- a/pangeo_fish/hmm/filter.py
+++ b/pangeo_fish/hmm/filter.py
@@ -1,3 +1,5 @@
+import warnings
+
 import dask
 import dask.array as da
 import numpy as np
@@ -43,6 +45,12 @@ def score(emission, predictor, initial_probability, mask=None):
         prediction = predictor.predict(previous, mask=mask)
         updated = prediction * dask.compute(emission[index, ...])[0]
 
+        if np.sum(updated) == 0:
+            warnings.warn(
+                f"Empty product of the prediction with the true distribution at step {index+1}.",
+                RuntimeWarning,
+            )
+            return 10e5
         normalizations.append(np.sum(updated))
         normalized = updated / normalizations[index]
 


### PR DESCRIPTION
Hi,

I talked to Jean-Marc about how to handle the cases where the predictions would miss out entirely the emission matrix (whose issue is #145).

For now, he suggested returning a very bad, big score, but not np.inf as I did to avoid downstream issues.

I arbitrarily set 1 million.  