### PR TITLE
move `xdggs` back into the pip section

### DIFF
--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -36,9 +36,9 @@ dependencies:
   - rich
   - rich-click
   - pip
-  - xdggs
   - pip:
       - cdshealpix
+      - xdggs
       - healpix-convolution
       - dask-hpcconfig
       - imageio[ffmpeg]


### PR DESCRIPTION
`xdggs` depends on `cdshealpix`, which doesn't yet have packages on conda-forge for MacOS-ARM CPUs (github somewhat recently switched all macos CI to ARM machines).